### PR TITLE
Handle Amazon ECR registries associated with other accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,33 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
+If you need to log in to Amazon ECR registries associated with other accounts, you can use the `AWS_ECR_REGISTRY_IDS`
+environment variable:
+
+```yaml
+name: ci
+
+on:
+  push:
+    branches: master
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: <aws-account-number>.dkr.ecr.<region>.amazonaws.com
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_ECR_REGISTRY_IDS: "012345678910 023456789012"
+```
+
+> Only available with [AWS CLI version 1](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html)
+
 You can also use the [Configure AWS Credentials](https://github.com/aws-actions/configure-aws-credentials) action in
 combination with this action:
 
@@ -311,41 +338,15 @@ jobs:
 
 > Replace `<region>` with its respective value (default `us-east-1`).
 
-You can also use the [Configure AWS Credentials](https://github.com/aws-actions/configure-aws-credentials) action in
-combination with this action:
-
-```yaml
-name: ci
-
-on:
-  push:
-    branches: master
-
-jobs:
-  login:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: <region>
-      -
-        name: Login to Public ECR
-        uses: docker/login-action@v1
-        with:
-          registry: public.ecr.aws
-```
-
-> Replace `<region>` with its respective value.
-
 ### OCI Oracle Cloud Infrastructure Registry (OCIR)
+
 To push into OCIR in specific tenancy the [username](https://www.oracle.com/webfolder/technetwork/tutorials/obe/oci/registry/index.html#LogintoOracleCloudInfrastructureRegistryfromtheDockerCLI)
-must be placed in format `<tenancy>/<username>` (in case of federated tenancy use the format `<tenancy-namespace>/oracleidentitycloudservice/<username>`). 
-For password [create an auth token](https://www.oracle.com/webfolder/technetwork/tutorials/obe/oci/registry/index.html#GetanAuthToken). Save username and token
- [as a secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository) in your GitHub repo. 
+must be placed in format `<tenancy>/<username>` (in case of federated tenancy use the format
+`<tenancy-namespace>/oracleidentitycloudservice/<username>`).
+
+For password [create an auth token](https://www.oracle.com/webfolder/technetwork/tutorials/obe/oci/registry/index.html#GetanAuthToken).
+Save username and token [as a secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)
+in your GitHub repo. 
 
 ```yaml
 name: ci
@@ -366,6 +367,7 @@ jobs:
           username: ${{ secrets.OCI_USERNAME }}
           password: ${{ secrets.OCI_TOKEN }}
 ```
+
 > Replace `<region>` with their respective values from [availability regions](https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryprerequisites.htm#Availab)
 
 ## Customizing

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ jobs:
 
 ### AWS Elastic Container Registry (ECR)
 
-Use an IAM user with the [ability to push to ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html).
+Use an IAM user with the ability to [push to ECR with `AmazonEC2ContainerRegistryPowerUser` managed policy for example](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html#AmazonEC2ContainerRegistryPowerUser).
 Then create and download access keys and save `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [as secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)
 in your GitHub repo.
 
@@ -251,7 +251,7 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
-If you need to log in to Amazon ECR registries associated with other accounts, you can use the `AWS_ECR_REGISTRY_IDS`
+If you need to log in to Amazon ECR registries associated with other accounts, you can use the `AWS_ACCOUNT_IDS`
 environment variable:
 
 ```yaml
@@ -273,7 +273,7 @@ jobs:
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         env:
-          AWS_ECR_REGISTRY_IDS: "012345678910 023456789012"
+          AWS_ACCOUNT_IDS: 012345678910,023456789012
 ```
 
 > Only available with [AWS CLI version 1](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html)
@@ -310,7 +310,7 @@ jobs:
 
 ### AWS Public Elastic Container Registry (ECR)
 
-Use an IAM user with the [ability to push to ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html).
+Use an IAM user with the ability to [push to ECR Public with `AmazonElasticContainerRegistryPublicPowerUser` managed policy for example](https://docs.aws.amazon.com/AmazonECR/latest/public/public-ecr-managed-policies.html#AmazonElasticContainerRegistryPublicPowerUser).
 Then create and download access keys and save `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [as secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)
 in your GitHub repo.
 

--- a/__tests__/aws.test.ts
+++ b/__tests__/aws.test.ts
@@ -6,6 +6,8 @@ describe('isECR', () => {
     ['registry.gitlab.com', false],
     ['gcr.io', false],
     ['012345678901.dkr.ecr.eu-west-3.amazonaws.com', true],
+    ['876820548815.dkr.ecr.cn-north-1.amazonaws.com.cn', true],
+    ['390948362332.dkr.ecr.cn-northwest-1.amazonaws.com.cn', true],
     ['public.ecr.aws', true]
   ])('given registry %p', async (registry, expected) => {
     expect(await aws.isECR(registry)).toEqual(expected);
@@ -17,6 +19,8 @@ describe('isPubECR', () => {
     ['registry.gitlab.com', false],
     ['gcr.io', false],
     ['012345678901.dkr.ecr.eu-west-3.amazonaws.com', false],
+    ['876820548815.dkr.ecr.cn-north-1.amazonaws.com.cn', false],
+    ['390948362332.dkr.ecr.cn-northwest-1.amazonaws.com.cn', false],
     ['public.ecr.aws', true]
   ])('given registry %p', async (registry, expected) => {
     expect(await aws.isPubECR(registry)).toEqual(expected);
@@ -59,8 +63,37 @@ describe('parseCLIVersion', () => {
 describe('getRegion', () => {
   test.each([
     ['012345678901.dkr.ecr.eu-west-3.amazonaws.com', 'eu-west-3'],
+    ['876820548815.dkr.ecr.cn-north-1.amazonaws.com.cn', 'cn-north-1'],
+    ['390948362332.dkr.ecr.cn-northwest-1.amazonaws.com.cn', 'cn-northwest-1'],
     ['public.ecr.aws', 'us-east-1']
   ])('given registry %p', async (registry, expected) => {
     expect(await aws.getRegion(registry)).toEqual(expected);
+  });
+});
+
+describe('getAccountIDs', () => {
+  test.each([
+    ['012345678901.dkr.ecr.eu-west-3.amazonaws.com', undefined, ['012345678901']],
+    [
+      '012345678901.dkr.ecr.eu-west-3.amazonaws.com',
+      '012345678910,023456789012',
+      ['012345678901', '012345678910', '023456789012']
+    ],
+    [
+      '012345678901.dkr.ecr.eu-west-3.amazonaws.com',
+      '012345678901,012345678910,023456789012',
+      ['012345678901', '012345678910', '023456789012']
+    ],
+    [
+      '390948362332.dkr.ecr.cn-northwest-1.amazonaws.com.cn',
+      '012345678910,023456789012',
+      ['390948362332', '012345678910', '023456789012']
+    ],
+    ['public.ecr.aws', undefined, []]
+  ])('given registry %p', async (registry, accountIDsEnv, expected) => {
+    if (accountIDsEnv) {
+      process.env.AWS_ACCOUNT_IDS = accountIDsEnv;
+    }
+    expect(await aws.getAccountIDs(registry)).toEqual(expected);
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -3088,6 +3088,7 @@ function loginECR(registry, username, password) {
         const cliPath = yield aws.getCLI();
         const cliVersion = yield aws.getCLIVersion();
         const region = yield aws.getRegion(registry);
+        const accountIDs = yield aws.getAccountIDs(registry);
         if (yield aws.isPubECR(registry)) {
             core.info(`💡 AWS Public ECR detected with ${region} region`);
         }
@@ -3097,7 +3098,7 @@ function loginECR(registry, username, password) {
         process.env.AWS_ACCESS_KEY_ID = username || process.env.AWS_ACCESS_KEY_ID;
         process.env.AWS_SECRET_ACCESS_KEY = password || process.env.AWS_SECRET_ACCESS_KEY;
         core.info(`⬇️ Retrieving docker login command through AWS CLI ${cliVersion} (${cliPath})...`);
-        const loginCmds = yield aws.getDockerLoginCmds(cliVersion, registry, region);
+        const loginCmds = yield aws.getDockerLoginCmds(cliVersion, registry, region, accountIDs);
         core.info(`🔑 Logging into ${registry}...`);
         loginCmds.forEach((loginCmd, index) => {
             execm.exec(loginCmd, [], true).then(res => {
@@ -4167,22 +4168,41 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getDockerLoginCmds = exports.parseCLIVersion = exports.getCLIVersion = exports.execCLI = exports.getCLI = exports.getRegion = exports.isPubECR = exports.isECR = void 0;
+exports.getDockerLoginCmds = exports.parseCLIVersion = exports.getCLIVersion = exports.execCLI = exports.getCLI = exports.getAccountIDs = exports.getRegion = exports.isPubECR = exports.isECR = void 0;
 const semver = __importStar(__webpack_require__(383));
 const io = __importStar(__webpack_require__(436));
 const execm = __importStar(__webpack_require__(757));
-exports.isECR = (registry) => __awaiter(void 0, void 0, void 0, function* () {
-    return registry.includes('amazonaws') || (yield exports.isPubECR(registry));
-});
-exports.isPubECR = (registry) => __awaiter(void 0, void 0, void 0, function* () {
+const ecrRegistryRegex = /^(([0-9]{12})\.dkr\.ecr\.(.+)\.amazonaws\.com(.cn)?)(\/([^:]+)(:.+)?)?$/;
+exports.isECR = (registry) => {
+    return ecrRegistryRegex.test(registry) || exports.isPubECR(registry);
+};
+exports.isPubECR = (registry) => {
     return registry === 'public.ecr.aws';
-});
-exports.getRegion = (registry) => __awaiter(void 0, void 0, void 0, function* () {
-    if (yield exports.isPubECR(registry)) {
+};
+exports.getRegion = (registry) => {
+    if (exports.isPubECR(registry)) {
         return process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
     }
-    return registry.substring(registry.indexOf('ecr.') + 4, registry.indexOf('.amazonaws'));
-});
+    const matches = registry.match(ecrRegistryRegex);
+    if (!matches) {
+        return '';
+    }
+    return matches[3];
+};
+exports.getAccountIDs = (registry) => {
+    if (exports.isPubECR(registry)) {
+        return [];
+    }
+    const matches = registry.match(ecrRegistryRegex);
+    if (!matches) {
+        return [];
+    }
+    let accountIDs = [matches[2]];
+    if (process.env.AWS_ACCOUNT_IDS) {
+        accountIDs.push(...process.env.AWS_ACCOUNT_IDS.split(','));
+    }
+    return accountIDs.filter((item, index) => accountIDs.indexOf(item) === index);
+};
 exports.getCLI = () => __awaiter(void 0, void 0, void 0, function* () {
     return io.which('aws', true);
 });
@@ -4209,7 +4229,7 @@ exports.parseCLIVersion = (stdout) => __awaiter(void 0, void 0, void 0, function
     }
     return semver.clean(matches[1]);
 });
-exports.getDockerLoginCmds = (cliVersion, registry, region) => __awaiter(void 0, void 0, void 0, function* () {
+exports.getDockerLoginCmds = (cliVersion, registry, region, accountIDs) => __awaiter(void 0, void 0, void 0, function* () {
     let ecrCmd = (yield exports.isPubECR(registry)) ? 'ecr-public' : 'ecr';
     if (semver.satisfies(cliVersion, '>=2.0.0')) {
         return exports.execCLI([ecrCmd, 'get-login-password', '--region', region]).then(pwd => {
@@ -4217,11 +4237,15 @@ exports.getDockerLoginCmds = (cliVersion, registry, region) => __awaiter(void 0,
         });
     }
     else {
-        let args = [ecrCmd, 'get-login', '--region', region, '--no-include-email'];
-        if (process.env.AWS_ECR_REGISTRY_IDS) {
-            args.push('--registry-ids', process.env.AWS_ECR_REGISTRY_IDS);
-        }
-        return exports.execCLI(args).then(dockerLoginCmds => {
+        return exports.execCLI([
+            ecrCmd,
+            'get-login',
+            '--region',
+            region,
+            '--registry-ids',
+            accountIDs.join(' '),
+            '--no-include-email'
+        ]).then(dockerLoginCmds => {
             return dockerLoginCmds.trim().split(`\n`);
         });
     }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -44,6 +44,7 @@ export async function loginECR(registry: string, username: string, password: str
   const cliPath = await aws.getCLI();
   const cliVersion = await aws.getCLIVersion();
   const region = await aws.getRegion(registry);
+  const accountIDs = await aws.getAccountIDs(registry);
 
   if (await aws.isPubECR(registry)) {
     core.info(`💡 AWS Public ECR detected with ${region} region`);
@@ -55,7 +56,7 @@ export async function loginECR(registry: string, username: string, password: str
   process.env.AWS_SECRET_ACCESS_KEY = password || process.env.AWS_SECRET_ACCESS_KEY;
 
   core.info(`⬇️ Retrieving docker login command through AWS CLI ${cliVersion} (${cliPath})...`);
-  const loginCmds = await aws.getDockerLoginCmds(cliVersion, registry, region);
+  const loginCmds = await aws.getDockerLoginCmds(cliVersion, registry, region, accountIDs);
 
   core.info(`🔑 Logging into ${registry}...`);
   loginCmds.forEach((loginCmd, index) => {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -55,13 +55,19 @@ export async function loginECR(registry: string, username: string, password: str
   process.env.AWS_SECRET_ACCESS_KEY = password || process.env.AWS_SECRET_ACCESS_KEY;
 
   core.info(`⬇️ Retrieving docker login command through AWS CLI ${cliVersion} (${cliPath})...`);
-  const loginCmd = await aws.getDockerLoginCmd(cliVersion, registry, region);
+  const loginCmds = await aws.getDockerLoginCmds(cliVersion, registry, region);
 
   core.info(`🔑 Logging into ${registry}...`);
-  execm.exec(loginCmd, [], true).then(res => {
-    if (res.stderr != '' && !res.success) {
-      throw new Error(res.stderr);
-    }
-    core.info('🎉 Login Succeeded!');
+  loginCmds.forEach((loginCmd, index) => {
+    execm.exec(loginCmd, [], true).then(res => {
+      if (res.stderr != '' && !res.success) {
+        throw new Error(res.stderr);
+      }
+      if (loginCmds.length > 1) {
+        core.info(`🎉 Login Succeeded! (${index}/${loginCmds.length})`);
+      } else {
+        core.info('🎉 Login Succeeded!');
+      }
+    });
   });
 }


### PR DESCRIPTION
Fixes #39 
Fixes docker/build-push-action#253

cc. @michaelb990

@davidski Can be tested with:

```yaml
name: ci

on:
  push:
    branches: master

jobs:
  login:
    runs-on: ubuntu-latest
    steps:
      -
        name: Login to ECR
        uses: crazy-max/docker-login-action@registry-ids
        with:
          registry: <aws-account-number>.dkr.ecr.<region>.amazonaws.com
          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
        env:
          AWS_ACCOUNT_IDS: 012345678910,023456789012
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>