### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Paris"
     labels:
       - ":game_die: dependencies"
       - ":robot: bot"
@@ -13,8 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Paris"
     allow:
       - dependency-type: "production"
     labels:


### PR DESCRIPTION
Looks like dependabot is not enabled on the repo even if the file is [already here](https://github.com/docker/login-action/blob/28218f9b04b4f3f62068d7b6ce6ca5b26e35336c/.github/dependabot.yml):

![image](https://user-images.githubusercontent.com/1951866/119415016-09a6d200-bcf1-11eb-9236-73f6fd7840d2.png)

Try to edit this file to see if it changes smth upstream.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>