### PR TITLE
Ubuntu 16.04 runner deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
     steps:
       -
         name: Checkout
@@ -102,9 +102,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
     steps:
       -
         name: Checkout
@@ -123,9 +123,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
     steps:
       -
         name: Checkout
@@ -149,9 +149,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
     steps:
       -
         name: Checkout


### PR DESCRIPTION
> The ubuntu-16.04 environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details see https://github.com/actions/virtual-environments/issues/3287

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>