### PR TITLE
dependabot: group aws-sdk and proxy-agent dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      aws-sdk-dependencies:
+        patterns:
+          - "*aws-sdk*"
+      proxy-agent-dependencies:
+        patterns:
+          - "*-proxy-agent"
     allow:
       - dependency-type: "production"
     labels:


### PR DESCRIPTION
related to:
* https://github.com/github/roadmap/issues/148#issuecomment-1629826280
* https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/