### PR TITLE
feat: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Stop docker
         run: |
@@ -39,7 +39,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to GitHub Container Registry
         uses: ./
@@ -56,7 +56,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to GitHub Container Registry
         uses: ./
@@ -81,7 +81,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to ACR
         uses: ./
@@ -101,7 +101,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to Docker Hub
         uses: ./
@@ -120,7 +120,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to ECR
         uses: ./
@@ -140,7 +140,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -165,7 +165,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to Public ECR
         uses: ./
@@ -187,7 +187,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -212,7 +212,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to GitHub Container Registry
         uses: ./
@@ -232,7 +232,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to GitLab
         uses: ./
@@ -252,7 +252,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to Google Artifact Registry
         uses: ./
@@ -272,7 +272,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Login to Google Container Registry
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Test
         uses: docker/bake-action@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Targets matrix
         id: targets
@@ -33,7 +33,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Validate
         uses: docker/bake-action@v3

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
**Description:**

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to `node20` (Node 20) (https://github.com/actions/runner/pull/2732). I have also bumped the actions/checkout version to v4 for the same.

-----------------
A major version bump might be needed after the PRs merge.

Closes #589