### PR TITLE
ci(codeql): restrict code scanning to src folder

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,9 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          config: |
+            paths:
+              - src
       -
         name: Autobuild
         uses: github/codeql-action/autobuild@v2


### PR DESCRIPTION
CodeQL currently scans `dist` folder which contains source code not introduced by this repository and could trigger false-positives. This should only scan `src` folder per https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan