### PR TITLE
bump codecov/codecov-action from 3 to 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           targets: test
       -
         name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
related to https://github.com/docker/login-action/actions/runs/7934435026

![image](https://github.com/docker/login-action/assets/1951866/85cd54ef-89af-4654-9a4e-5607c82669de)
