### PR TITLE
ci: publish as immutable action workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Publish
+        uses: actions/publish-immutable-action@v0.0.4


### PR DESCRIPTION
~Keeping in draft while Actions package is not yet activated.~

Edit: Actions package activated: https://github.com/docker/login-action/pkgs/container/login-action

cc @chris-crone @thompson-shaun @tonistiigi 