### PR TITLE
add retries for 502

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Log out from the Docker registry at the end of a job'
     default: 'true'
     required: false
+  attetmps:
+    description: 'Number of attempts to try in case of server-side errors'
+    default: '1'
+    required: false
 
 runs:
   using: 'node20'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'Log out from the Docker registry at the end of a job'
     default: 'true'
     required: false
-  attetmps:
+  attempts:
     description: 'Number of attempts to try in case of server-side errors'
     default: '1'
     required: false

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ export interface Inputs {
   password: string;
   ecr: string;
   logout: boolean;
+  attempts: number;
 }
 
 export function getInputs(): Inputs {
@@ -14,6 +15,7 @@ export function getInputs(): Inputs {
     username: core.getInput('username'),
     password: core.getInput('password'),
     ecr: core.getInput('ecr'),
-    logout: core.getBooleanInput('logout')
+    logout: core.getBooleanInput('logout'),
+    attempts: Number.parseInt(core.getInput('attempts'))
   };
 }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -3,11 +3,11 @@ import * as core from '@actions/core';
 
 import {Docker} from '@docker/actions-toolkit/lib/docker/docker';
 
-export async function login(registry: string, username: string, password: string, ecr: string): Promise<void> {
+export async function login(registry: string, username: string, password: string, ecr: string, attempts: number): Promise<void> {
   if (/true/i.test(ecr) || (ecr == 'auto' && aws.isECR(registry))) {
     await loginECR(registry, username, password);
   } else {
-    await loginStandard(registry, username, password);
+    await loginStandard(registry, username, password, attempts);
   }
 }
 
@@ -21,7 +21,7 @@ export async function logout(registry: string): Promise<void> {
   });
 }
 
-export async function loginStandard(registry: string, username: string, password: string): Promise<void> {
+export async function loginStandard(registry: string, username: string, password: string, attempts: number): Promise<void> {
   if (!username && !password) {
     throw new Error('Username and password required');
   }
@@ -41,16 +41,29 @@ export async function loginStandard(registry: string, username: string, password
   } else {
     core.info(`Logging into Docker Hub...`);
   }
-  await Docker.getExecOutput(loginArgs, {
-    ignoreReturnCode: true,
-    silent: true,
-    input: Buffer.from(password)
-  }).then(res => {
-    if (res.stderr.length > 0 && res.exitCode != 0) {
-      throw new Error(res.stderr.trim());
+  let attempt: number = 1
+  let succeeded: boolean = false
+  for (let attempt = 1; (attempt <= attempts) && (!succeeded); attempt++) {
+    await Docker.getExecOutput(loginArgs, {
+      ignoreReturnCode: true,
+      silent: true,
+      input: Buffer.from(password)
+    }).then(res => {
+      if (res.stderr.length > 0 && res.exitCode != 0) {
+        let isRetriable: boolean
+        isRetriable = res.stderr.endsWith("502 Bad Gateway")
+        if (!isRetriable || (attempt >= attempts) {
+          throw new Error(res.stderr.trim());
+        }
+      } else {
+        core.info(`Login Succeeded!`);
+        succeeded = true;
+      }
+    });
+    if ((attempt < attempts) && !succeeded) {
+      await new Promise(r => setTimeout(r, 10000))
     }
-    core.info(`Login Succeeded!`);
-  });
+  }
 }
 
 export async function loginECR(registry: string, username: string, password: string): Promise<void> {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -51,7 +51,7 @@ export async function loginStandard(registry: string, username: string, password
     }).then(res => {
       if (res.stderr.length > 0 && res.exitCode != 0) {
         let isRetriable: boolean
-        isRetriable = res.stderr.endsWith("502 Bad Gateway")
+        isRetriable = res.stderr.trim().endsWith("502 Bad Gateway")
         if (!isRetriable || (attempt >= attempts) {
           throw new Error(res.stderr.trim());
         }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -51,7 +51,12 @@ export async function loginStandard(registry: string, username: string, password
     }).then(res => {
       if (res.stderr.length > 0 && res.exitCode != 0) {
         let isRetriable: boolean
-        isRetriable = res.stderr.trim().endsWith("502 Bad Gateway")
+function isRetriableError(stderr: string): boolean {
+    const trimmedError = stderr.trim();
+    return trimmedError.endsWith("502 Bad Gateway") || trimmedError.includes("408");
+}
+
+isRetriable = isRetriableError(res.stderr);
         if (!isRetriable || (attempt >= attempts) {
           throw new Error(res.stderr.trim());
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ export async function main(): Promise<void> {
   const input: context.Inputs = context.getInputs();
   stateHelper.setRegistry(input.registry);
   stateHelper.setLogout(input.logout);
-  await docker.login(input.registry, input.username, input.password, input.ecr);
+  await docker.login(input.registry, input.username, input.password, input.ecr, input.attempts);
 }
 
 async function post(): Promise<void> {


### PR DESCRIPTION
Fix: https://github.com/docker/login-action/issues/750

- Retry only 5xx errors (502 for now) as dont need to retry bad login/passwords
- Sleep 10s before attempts. It could be configurable, but shouldn't bit less than 10s.
- Delay could be with exponential backoff, or just simple approach with no more than 3 attempts and constant 10s delay, IMO, should be enough for `docker login`