### PR TITLE
document ACR OIDC login with Azure Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ jobs:
     -
       name: Authenticate to Google Cloud
       id: auth
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v3
       with:
         token_format: access_token
         workload_identity_provider: <workload_identity_provider>
@@ -300,7 +300,7 @@ jobs:
       -
         name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v3
         with:
           token_format: access_token
           workload_identity_provider: <workload_identity_provider>
@@ -426,7 +426,7 @@ jobs:
     steps:
       -
         name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -662,7 +662,7 @@ jobs:
           scope: 'myorg/myimage@push'
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: myorg/myimage:latest

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ jobs:
           password: ${{ secrets.AZURE_CLIENT_SECRET }}
 ```
 
+> [!NOTE]
 > Replace `<registry-name>` with the name of your registry.
 
 #### OpenID Connect (OIDC)
@@ -191,10 +192,12 @@ jobs:
           password: ${{ steps.acr-token.outputs.token }}
 ```
 
+> [!NOTE]
 > Replace `<registry-name>` with the name of your registry.
 
 ### Google Container Registry (GCR)
 
+> [!NOTE]
 > [Google Artifact Registry](#google-artifact-registry-gar) is the evolution of
 > Google Container Registry. As a fully-managed service with support for both
 > container images and non-container artifacts. If you currently use Google
@@ -239,9 +242,10 @@ jobs:
         password: ${{ steps.auth.outputs.access_token }}
 ```
 
+> [!NOTE]
 > Replace `<workload_identity_provider>` with configured workload identity
 > provider. For steps to configure, [see here](https://github.com/google-github-actions/auth#setting-up-workload-identity-federation).
-
+>
 > Replace `<service_account>` with configured service account in workload
 > identity provider which has access to push to GCR
 
@@ -310,12 +314,13 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 ```
 
+> [!NOTE]
 > Replace `<workload_identity_provider>` with configured workload identity
 > provider
-
+>
 > Replace `<service_account>` with configured service account in workload
 > identity provider which has access to push to GCR
-
+>
 > Replace `<location>` with the regional or multi-regional [location](https://cloud.google.com/artifact-registry/docs/repo-organize#locations)
 > of the repository where the image is stored.
 
@@ -347,6 +352,7 @@ jobs:
           password: ${{ secrets.GAR_JSON_KEY }}
 ```
 
+> [!NOTE]
 > Replace `<location>` with the regional or multi-regional [location](https://cloud.google.com/artifact-registry/docs/repo-organize#locations)
 > of the repository where the image is stored.
 
@@ -401,6 +407,7 @@ jobs:
           AWS_ACCOUNT_IDS: 012345678910,023456789012
 ```
 
+> [!NOTE]
 > Only available with [AWS CLI version 1](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html)
 
 You can also use the [Configure AWS Credentials](https://github.com/aws-actions/configure-aws-credentials)
@@ -431,6 +438,7 @@ jobs:
           registry: <aws-account-number>.dkr.ecr.<region>.amazonaws.com
 ```
 
+> [!NOTE]
 > Replace `<aws-account-number>` and `<region>` with their respective values.
 
 ### AWS Public Elastic Container Registry (ECR)
@@ -462,6 +470,7 @@ jobs:
           AWS_REGION: <region>
 ```
 
+> [!NOTE]
 > Replace `<region>` with its respective value (default `us-east-1`).
 
 ### OCI Oracle Cloud Infrastructure Registry (OCIR)
@@ -494,6 +503,7 @@ jobs:
           password: ${{ secrets.OCI_TOKEN }}
 ```
 
+> [!NOTE]
 > Replace `<region>` with their respective values from [availability regions](https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryprerequisites.htm#Availab)
 
 ### Quay.io

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ instead of a password.
 
 ### Azure Container Registry (ACR)
 
+#### Service principal
+
 [Create a service principal](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal#create-a-service-principal)
 with access to your container registry through the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 and take note of the generated service principal's ID (also called _client ID_)
@@ -140,6 +142,53 @@ jobs:
           registry: <registry-name>.azurecr.io
           username: ${{ vars.AZURE_CLIENT_ID }}
           password: ${{ secrets.AZURE_CLIENT_SECRET }}
+```
+
+> Replace `<registry-name>` with the name of your registry.
+
+#### OpenID Connect (OIDC)
+
+To authenticate with OpenID Connect, configure a federated identity credential
+for GitHub Actions and use the [Azure Login](https://github.com/Azure/login)
+action to sign in to Azure. Then expose an ACR access token and pass it to this
+action as the password.
+
+```yaml
+name: ci
+
+on:
+  push:
+    branches: main
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      -
+        name: Get ACR access token
+        id: acr-token
+        run: |
+          ACR_TOKEN=$(az acr login --name <registry-name> --expose-token --output tsv --query accessToken)
+          echo "::add-mask::$ACR_TOKEN" # mask the token in workflow logs
+          echo "token=$ACR_TOKEN" >> "$GITHUB_OUTPUT"
+      -
+        name: Login to ACR
+        uses: docker/login-action@v4
+        with:
+          registry: <registry-name>.azurecr.io
+          username: 00000000-0000-0000-0000-000000000000
+          password: ${{ steps.acr-token.outputs.token }}
 ```
 
 > Replace `<registry-name>` with the name of your registry.


### PR DESCRIPTION
fixes #700 
fixes #767 

The ACR README section now separates service principal authentication from OIDC authentication, and the new OIDC example shows how to expose an ACR access token with `az acr login --expose-token` before 
passing it to `docker/login-action`.