### PR TITLE
ci: update registry auth credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
         name: Login to Google Artifact Registry
         uses: ./
         with:
-          registry: ${{ secrets.GAR_LOCATION }}-docker.pkg.dev
+          registry: us-east4-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,8 @@ jobs:
         name: Login to Docker Hub
         uses: ./
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
 
   ecr:
     runs-on: ${{ matrix.os }}
@@ -335,8 +335,8 @@ jobs:
         uses: ./
         with:
           registry-auth: |
-            - username: ${{ secrets.DOCKERHUB_USERNAME }}
-              password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+              password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
             - registry: ghcr.io
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
@@ -384,8 +384,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry-auth: |
-            - username: ${{ secrets.DOCKERHUB_USERNAME }}
-              password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+              password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
       -
         name: Check
         run: |
@@ -410,8 +410,8 @@ jobs:
         name: Login to Docker Hub
         uses: ./
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
           scope: '@push'
       -
         name: Print config.json files
@@ -440,8 +440,8 @@ jobs:
         name: Login to Docker Hub
         uses: ./
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
           scope: 'docker/buildx-bin@push'
       -
         name: Print config.json files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         name: Login to ACR
         uses: ./
         with:
-          registry: ${{ secrets.AZURE_REGISTRY_NAME }}.azurecr.io
+          registry: officialgithubactions.azurecr.io
           username: ${{ secrets.AZURE_CLIENT_ID }}
           password: ${{ secrets.AZURE_CLIENT_SECRET }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         name: Login to ECR
         uses: ./
         with:
-          registry: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.us-east-1.amazonaws.com
+          registry: 175142243308.dkr.ecr.us-east-1.amazonaws.com
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -193,7 +193,7 @@ jobs:
         name: Login to ECR
         uses: ./
         with:
-          registry: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.us-east-1.amazonaws.com
+          registry: 175142243308.dkr.ecr.us-east-1.amazonaws.com
 
   ecr-public:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This updates CI login coverage to use the current registry hosts and Docker public bot credentials.

The workflow now uses fixed ACR, ECR, and GAR registry endpoints, and Docker Hub login steps now authenticate with `DOCKERPUBLICBOT_USERNAME` and `DOCKERPUBLICBOT_READ_PAT`.

The previous workflow depended on older secret names for Docker Hub credentials and registry host construction, which makes the CI setup harder to keep aligned with the current repository secrets and registry configuration.