### PR TITLE
ci: replace GHCR PAT in DinD test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GHCR_TEST_IMAGE: ghcr.io/docker/login-action-test:ci-${{ github.sha }}
+
 on:
   workflow_dispatch:
   schedule:
@@ -56,8 +59,39 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: ${{ matrix.logout }}
 
+  push-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      -
+        name: Login to GitHub Container Registry
+        uses: ./
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push test image
+        run: |
+          docker buildx build --push -t "${GHCR_TEST_IMAGE}" - <<EOF
+          FROM scratch
+          LABEL org.opencontainers.image.title="docker/login-action CI test image"
+          LABEL org.opencontainers.image.description="Empty image used by CI to verify GHCR authentication."
+          LABEL org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
+          EOF
+
   dind:
     runs-on: ubuntu-latest
+    needs:
+      - push-ghcr
+    permissions:
+      contents: read
+      packages: read
     env:
       DOCKER_CONFIG: $HOME/.docker
     steps:
@@ -69,19 +103,19 @@ jobs:
         uses: ./
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: DinD
         uses: docker://docker:29.3@sha256:4d90f1f6c400315c2dba96d3ec93c01e64198395cbba04f79d12adce4f737029
         with:
           entrypoint: docker
-          args: pull ghcr.io/docker-ghactiontest/test
+          args: pull ${{ env.GHCR_TEST_IMAGE }}
       -
-        name: Pull private image
+        name: Pull test image
         run: |
           docker image prune -a -f >/dev/null 2>&1
-          docker pull ghcr.io/docker-ghactiontest/test
+          docker pull "${GHCR_TEST_IMAGE}"
 
   acr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This updates the DinD CI test so it no longer depends on a long-lived GHCR PAT.

The workflow now builds and pushes a dummy GHCR image with `GITHUB_TOKEN`, then the DinD job pulls that image with `GITHUB_TOKEN` using package read permissions.

This keeps the test image inside the `docker/login-action` package scope and removes the dependency on the separate `docker-ghactiontest/test` package and its PAT-based credentials.