### PR TITLE
ci: replace registry container action reference

### DIFF
--- a/.github/actions/docker-pull/Dockerfile
+++ b/.github/actions/docker-pull/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker:29.3@sha256:4d90f1f6c400315c2dba96d3ec93c01e64198395cbba04f79d12adce4f737029
+
+ENTRYPOINT ["docker"]

--- a/.github/actions/docker-pull/action.yml
+++ b/.github/actions/docker-pull/action.yml
@@ -1,0 +1,15 @@
+name: Pull Docker image
+
+description: Pull an image from a Docker container action
+
+inputs:
+  image:
+    description: Image reference to pull
+    required: true
+
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - pull
+    - ${{ inputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: DinD
-        uses: docker://docker:29.3@sha256:4d90f1f6c400315c2dba96d3ec93c01e64198395cbba04f79d12adce4f737029
+        name: Pull test image from Docker CLI container action
+        uses: ./.github/actions/docker-pull
         with:
-          entrypoint: docker
-          args: pull ${{ env.GHCR_TEST_IMAGE }}
+          image: ${{ env.GHCR_TEST_IMAGE }}
       -
         name: Pull test image
         run: |


### PR DESCRIPTION
## Summary

- replace the unsupported `uses: docker://docker` reference with a local `docker-pull` container action
- pin the Docker CLI base image by digest in the local action's Dockerfile
- preserve the existing integration coverage for credentials used from a GitHub Actions container action

## Why

Organization action allowlists do not support container actions referenced with `docker://` notation.

The initial approach used a manual `docker run`, but that was not equivalent: it bypassed GitHub Runner's container-action handling and manually supplied the socket and Docker configuration mounts.

This revision instead invokes a narrowly scoped local action:

```yaml
uses: ./.github/actions/docker-pull
```

The local action declares `runs.using: docker`, so GitHub Runner still builds and executes a real container action with its standard Docker socket, temporary home, workspace, and environment mounts. This retains the behavior the test is intended to cover while allowing the organization action allowlist to be enforced.

## Validation

- `actionlint .github/workflows/ci.yml`
- `docker build -t login-action-docker-pull-test .github/actions/docker-pull`
- `docker run --rm login-action-docker-pull-test --version`
- `git diff --check`
- verified no `uses: docker://` references remain
